### PR TITLE
v0.6.0: Update the header Sparked image link to point to the Sparked page & dependency on hl7.au.fhir.template 0.11.0

### DIFF
--- a/includes/_append.fragment-header.html
+++ b/includes/_append.fragment-header.html
@@ -1,5 +1,6 @@
         <div id="project-nav">
-          <a id="project-logo" no-external="true" href="https://confluence.hl7.org/display/HA/Sparked+FHIR+Accelerator"><img height="50" alt="Sparked FHIR Accelerator" src="{{site.data.info.assets}}assets/images/sparked-logo.png"/> </a>
+          <a id="project-logo" no-external="true" href="https://sparked.csiro.au/">
+            <img height="50" alt="Visit the Sparked website" src="{{site.data.info.assets}}assets/images/sparked-logo.png"/> </a>
         </div>
 
         <!--<div id="hl7-search">

--- a/package-list.json
+++ b/package-list.json
@@ -12,13 +12,21 @@
       "current" : true
     },
     {
+      "version" : "0.6.0",
+      "path" : "http://fhir.org/templates/hl7.au.sparked.template/0.6.0",
+      "status" : "release",
+      "sequence" : "Publications",
+      "fhirversion" : "4.0.1",
+      "desc" : "Update the header Sparked image link to point to the Sparked page, and upgrade for dependency on hl7.au.fhir.template 0.11.0",
+      "current" : true
+    },
+    {
       "version" : "0.5.0",
       "path" : "http://fhir.org/templates/hl7.au.sparked.template/0.5.0",
       "status" : "release",
       "sequence" : "Publications",
       "fhirversion" : "4.0.1",
       "desc" : "Upgrade for dependency on hl7.au.fhir.template 0.10.0",
-      "current" : true,
       "date" : "2024-11-12"
     },
     {

--- a/package/package.json
+++ b/package/package.json
@@ -7,7 +7,7 @@
   "canonical" : "http://fhir.org/templates/hl7.au.sparked.template",
   "base" : "hl7.au.fhir.template",
   "dependencies" : {
-    "hl7.au.fhir.template" : "current"
+    "hl7.au.fhir.template" : "0.11.0"
   },
-  "version" : "0.5.0"
+  "version" : "0.6.0"
 }


### PR DESCRIPTION
v0.6.0:
- Update the header Sparked image alt text and URL to point to the Sparked page https://sparked.csiro.au/
- Update for dependency on hl7.au.fhir.template 0.11.0